### PR TITLE
daab-loginのログイン先サーバを .env で変更できるように

### DIFF
--- a/lib/daab-login.js
+++ b/lib/daab-login.js
@@ -4,7 +4,10 @@
 var program = require('commander');
 var auth = require('./auth');
 var direct = require("direct-js").DirectAPI.getInstance();
+var url = require('url');
+require('dotenv').config();
 var proxyURL = process.env.HUBOT_DIRECT_PROXY_URL || process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+var endpoint = process.env.HUBOT_DIRECT_ENDPOINT || "wss://api.direct4b.com/albero-app-server/api";
 
 program
   .allowUnknownOption()
@@ -16,7 +19,7 @@ if (auth.hasToken()) {
 }
 
 direct.setOptions({
-  host:'api.direct4b.com', endpoint:'wss://api.direct4b.com/albero-app-server/api', proxyURL: proxyURL
+  host:url.parse(endpoint).host, endpoint:endpoint, proxyURL: proxyURL
 });
 direct.listen();
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "commander": "^2.8.1",
     "read": "^1.0.7",
-    "direct-js": "^0.1.0"
+    "direct-js": "^0.1.0",
+    "dotenv": "^4.0.0"
   }
 }


### PR DESCRIPTION
daab-login のログイン先サーバを .env の HUBOT_DIRECT_ENDPOINT で変更できるようにしました。
.envからの情報ロードは dotenv 使うようにしていますが、必要無いなら削除をお願いします