### PR TITLE
daab init をよくある project generator のような動きにする

### DIFF
--- a/lib/daab-init.js
+++ b/lib/daab-init.js
@@ -1,20 +1,16 @@
 #!/usr/bin/env node
 // daab init
 
-var cloneUrl = 'https://github.com/lisb/daab-starter.git';
-
-var program = require('commander');
-var git = require('./git');
+const program = require('commander');
+const { Template } = require('./template');
 
 program
   .allowUnknownOption()
   .parse(process.argv);
 
-git.init(['.'], function() {
-  git.remote(['add', 'daab-starter', cloneUrl], function() {
-    git.pull(['daab-starter', 'master'], function() {
-      console.log('daab initialized.');
-    });
-  });
-});
+const destinationRoot = process.cwd();
+const context = {};
 
+new Template().copyTo(destinationRoot, context, () => {
+  console.log('daab initialized.');
+});

--- a/lib/daab-init.js
+++ b/lib/daab-init.js
@@ -6,7 +6,20 @@ const inquirer = require("inquirer");
 const path = require("path");
 const { Template } = require("./template");
 
-program.allowUnknownOption().parse(process.argv);
+program
+  .option("--no-prompt", "not ask questions to fill items, use preset values")
+  .allowUnknownOption()
+  .parse(process.argv);
+
+const prompt = program.prompt !== false;
+
+const start = (template, defaults, prompt) => {
+  if (prompt) {
+    return inquirer.prompt(template.questions(defaults));
+  } else {
+    return Promise.resolve(template.daabStarter);
+  }
+};
 
 const template = new Template();
 const destinationRoot = process.cwd();
@@ -14,7 +27,7 @@ const defaults = {
   packageName: path.basename(destinationRoot)
 };
 
-inquirer.prompt(template.questions(defaults)).then(answers => {
+start(template, defaults, prompt).then(answers => {
   template.copyTo(destinationRoot, answers, () => {
     console.log("daab initialized.");
   });

--- a/lib/daab-init.js
+++ b/lib/daab-init.js
@@ -1,14 +1,12 @@
 #!/usr/bin/env node
 // daab init
 
-const program  = require('commander');
-const inquirer = require('inquirer');
-const path     = require('path');
-const { Template } = require('./template');
+const program = require("commander");
+const inquirer = require("inquirer");
+const path = require("path");
+const { Template } = require("./template");
 
-program
-  .allowUnknownOption()
-  .parse(process.argv);
+program.allowUnknownOption().parse(process.argv);
 
 const template = new Template();
 const destinationRoot = process.cwd();
@@ -16,10 +14,8 @@ const defaults = {
   packageName: path.basename(destinationRoot)
 };
 
-inquirer
-  .prompt(template.questions(defaults))
-  .then(answers => {
-    template.copyTo(destinationRoot, answers, () => {
-      console.log('daab initialized.');
-    });
+inquirer.prompt(template.questions(defaults)).then(answers => {
+  template.copyTo(destinationRoot, answers, () => {
+    console.log("daab initialized.");
   });
+});

--- a/lib/daab-init.js
+++ b/lib/daab-init.js
@@ -1,16 +1,25 @@
 #!/usr/bin/env node
 // daab init
 
-const program = require('commander');
+const program  = require('commander');
+const inquirer = require('inquirer');
+const path     = require('path');
 const { Template } = require('./template');
 
 program
   .allowUnknownOption()
   .parse(process.argv);
 
+const template = new Template();
 const destinationRoot = process.cwd();
-const context = {};
+const defaults = {
+  packageName: path.basename(destinationRoot)
+};
 
-new Template().copyTo(destinationRoot, context, () => {
-  console.log('daab initialized.');
-});
+inquirer
+  .prompt(template.questions(defaults))
+  .then(answers => {
+    template.copyTo(destinationRoot, answers, () => {
+      console.log('daab initialized.');
+    });
+  });

--- a/lib/template.js
+++ b/lib/template.js
@@ -3,82 +3,84 @@
 // This software is released under the MIT License.
 // https://opensource.org/licenses/MIT
 
-const memfs  = require('mem-fs');
-const editor = require('mem-fs-editor');
-const path   = require('path');
-const yeoman = require('yeoman-environment');
+const memfs = require("mem-fs");
+const editor = require("mem-fs-editor");
+const path = require("path");
+const yeoman = require("yeoman-environment");
 
 class Template {
   constructor() {
     const env = yeoman.createEnv();
     const res = env.lookup({
-      packagePatterns: 'daab',
-      filePatterns: 'lib/daab.js'
+      packagePatterns: "daab",
+      filePatterns: "lib/daab.js"
     });
     this._templateRoot = path.join(res[0].packagePath, "template");
   }
 
-  get requires() {
+  get required() {
     return [
-      'bin',
-      'scripts',
-      '.gitignore',
-      'external-scripts.json',
-      'package.json'
+      "bin",
+      "scripts",
+      ".gitignore",
+      "external-scripts.json",
+      "package.json"
     ];
   }
 
   get choices() {
-    return ['.cfignore', '.dockerignore', 'Berksfile', 'Dockerfile', 'Procfile', 'Vagrantfile'];
+    return [
+      ".cfignore",
+      ".dockerignore",
+      "Berksfile",
+      "Dockerfile",
+      "Procfile",
+      "Vagrantfile"
+    ];
   }
 
   questions(defaults) {
     return [
       {
-        name: 'packageName',
-        message: 'package name',
-        default: defaults['packageName']
+        name: "packageName",
+        message: "package name",
+        default: defaults["packageName"]
       },
       {
-        name: 'version',
-        message: 'version',
-        default: '0.1.0'
+        name: "version",
+        message: "version",
+        default: "0.1.0"
       },
       {
-        name: 'description',
-        message: 'description'
+        name: "description",
+        message: "description"
       },
       {
-        name: 'author',
-        message: 'author'
+        name: "author",
+        message: "author"
       },
       {
-        name: 'files',
-        type: 'checkbox',
-        message: 'choose files you need',
+        name: "files",
+        type: "checkbox",
+        message: "choose files you need",
         choices: this.choices
-      },
+      }
     ];
   }
 
   copyTo(dest, context, cb) {
-    const templatePath    = file => path.join(this._templateRoot, file);
+    const templatePath = file => path.join(this._templateRoot, file);
     const destinationPath = file => path.join(dest, file);
 
     const fs = editor.create(memfs.create());
-    this.requires.forEach(entry => {
-      fs.copyTpl(
-        templatePath(entry),
-        destinationPath(entry),
-        context
-      );
+    this.required.forEach(entry => {
+      fs.copyTpl(templatePath(entry), destinationPath(entry), context);
     });
-    this.choices.filter(c => context.files.includes(c)).forEach(entry => {
-      fs.copy(
-        templatePath(entry),
-        destinationPath(entry),
-      );
-    })
+    this.choices
+      .filter(c => context.files.includes(c))
+      .forEach(entry => {
+        fs.copy(templatePath(entry), destinationPath(entry));
+      });
     fs.commit(cb);
   }
 }

--- a/lib/template.js
+++ b/lib/template.js
@@ -68,6 +68,16 @@ class Template {
     ];
   }
 
+  get daabStarter() {
+    return {
+      packageName: "starter",
+      version: "0.3.9",
+      author: "L is B Corp.",
+      description: "A simple helpful robot for your Company",
+      files: this.choices
+    };
+  }
+
   copyTo(dest, context, cb) {
     const templatePath = file => path.join(this._templateRoot, file);
     const destinationPath = file => path.join(dest, file);

--- a/lib/template.js
+++ b/lib/template.js
@@ -1,0 +1,50 @@
+// Copyright (c) 2020 L is B
+//
+// This software is released under the MIT License.
+// https://opensource.org/licenses/MIT
+
+const memfs  = require('mem-fs');
+const editor = require('mem-fs-editor');
+const path   = require("path");
+const yeoman = require("yeoman-environment");
+
+class Template {
+  constructor() {
+    const env = yeoman.createEnv();
+    const res = env.lookup({
+      packagePatterns: 'daab',
+      filePatterns: 'lib/daab.js'
+    });
+    this._templateRoot = path.join(res[0].packagePath, "template");
+  }
+
+  copyTo(dest, context, cb) {
+    const templatePath = file => path.join(this._templateRoot, file);
+    const destinationPath = file => path.join(dest, file);
+
+    const files = [
+      'bin',
+      'scripts',
+      '.cfignore',
+      '.dockerignore',
+      '.gitignore',
+      'Berksfile',
+      'Dockerfile',
+      'external-scripts.json',
+      'package.json',
+      'Procfile',
+      'Vagrantfile'
+    ];
+    const fs = editor.create(memfs.create());
+    files.forEach(file => {
+      fs.copyTpl(
+        templatePath(file),
+        destinationPath(file),
+        context
+      );
+    });
+    fs.commit(cb);
+  }
+}
+
+module.exports = { Template };

--- a/lib/template.js
+++ b/lib/template.js
@@ -5,8 +5,8 @@
 
 const memfs  = require('mem-fs');
 const editor = require('mem-fs-editor');
-const path   = require("path");
-const yeoman = require("yeoman-environment");
+const path   = require('path');
+const yeoman = require('yeoman-environment');
 
 class Template {
   constructor() {
@@ -18,31 +18,67 @@ class Template {
     this._templateRoot = path.join(res[0].packagePath, "template");
   }
 
-  copyTo(dest, context, cb) {
-    const templatePath = file => path.join(this._templateRoot, file);
-    const destinationPath = file => path.join(dest, file);
-
-    const files = [
+  get requires() {
+    return [
       'bin',
       'scripts',
-      '.cfignore',
-      '.dockerignore',
       '.gitignore',
-      'Berksfile',
-      'Dockerfile',
       'external-scripts.json',
-      'package.json',
-      'Procfile',
-      'Vagrantfile'
+      'package.json'
     ];
+  }
+
+  get choices() {
+    return ['.cfignore', '.dockerignore', 'Berksfile', 'Dockerfile', 'Procfile', 'Vagrantfile'];
+  }
+
+  questions(defaults) {
+    return [
+      {
+        name: 'packageName',
+        message: 'package name',
+        default: defaults['packageName']
+      },
+      {
+        name: 'version',
+        message: 'version',
+        default: '0.1.0'
+      },
+      {
+        name: 'description',
+        message: 'description'
+      },
+      {
+        name: 'author',
+        message: 'author'
+      },
+      {
+        name: 'files',
+        type: 'checkbox',
+        message: 'choose files you need',
+        choices: this.choices
+      },
+    ];
+  }
+
+  copyTo(dest, context, cb) {
+    const templatePath    = file => path.join(this._templateRoot, file);
+    const destinationPath = file => path.join(dest, file);
+
     const fs = editor.create(memfs.create());
-    files.forEach(file => {
+    this.requires.forEach(entry => {
       fs.copyTpl(
-        templatePath(file),
-        destinationPath(file),
+        templatePath(entry),
+        destinationPath(entry),
         context
       );
     });
+    this.choices.filter(c => context.files.includes(c)).forEach(entry => {
+      fs.copy(
+        templatePath(entry),
+        destinationPath(entry),
+      );
+    })
     fs.commit(cb);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daab",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "daab (direct agent assist bot) commandline interface",
   "main": "lib/daab.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "commander": "^2.8.1",
     "direct-js": "^0.1.33",
     "dotenv": "^4.0.0",
+    "mem-fs-editor": "^6.0.0",
     "read": "^1.0.7",
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.2",
+    "yeoman-environment": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "commander": "^2.8.1",
     "direct-js": "^0.1.33",
     "dotenv": "^4.0.0",
+    "inquirer": "^7.0.4",
     "mem-fs-editor": "^6.0.0",
     "read": "^1.0.7",
     "rimraf": "^2.6.2",

--- a/template/.cfignore
+++ b/template/.cfignore
@@ -1,0 +1,9 @@
+node_modules
+.DS_Store*
+*~
+*.log
+.git
+.env
+storage.local
+dump.rdb
+

--- a/template/.dockerignore
+++ b/template/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.DS_Store*
+*~
+*.log
+.git
+.env
+storage.local
+dump.rdb
+

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.DS_Store*
+*~
+*.log
+.env
+storage.local
+dump.rdb

--- a/template/Berksfile
+++ b/template/Berksfile
@@ -1,0 +1,4 @@
+source "https://supermarket.getchef.com"
+cookbook 'redisio', '~> 2.2.4'
+cookbook 'daab', git: 'https://github.com/t-kudo/daab-cookbook.git'
+

--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:10 AS node_modules
+
+WORKDIR /daab
+COPY package.json .
+RUN npm install
+
+
+FROM node:10-alpine
+
+MAINTAINER masataka.takeuchi
+
+# set timezone JST
+RUN apk --no-cache add tzdata && \
+    cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime
+
+ENV NODE_ENV production
+ENV DISABLE_NPM_INSTALL true
+ENV HUBOT_ADAPTER=direct
+
+# httpd setting
+# ENV PORT 8080
+EXPOSE 8080
+
+# hubot files
+WORKDIR /daab
+COPY --from=node_modules /daab .
+COPY external-scripts.json .
+COPY bin bin
+COPY scripts scripts
+
+RUN sed -i -e 's/^#!\/bin\/bash/#!\/bin\/sh/' bin/hubot
+
+CMD bin/hubot run

--- a/template/Procfile
+++ b/template/Procfile
@@ -1,0 +1,1 @@
+web: bin/hubot run

--- a/template/Vagrantfile
+++ b/template/Vagrantfile
@@ -1,0 +1,181 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure(2) do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # vagrantup.com
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "Opscode centos-7.0"
+  config.vm.box_url = "http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-7.0_chef-provisionerless.box"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # Enable provisioning with CFEngine. CFEngine Community packages are
+  # automatically installed. For example, configure the host as a
+  # policy server and optionally a policy file to run:
+  #
+  # config.vm.provision "cfengine" do |cf|
+  #   cf.am_policy_hub = true
+  #   # cf.run_file = "motd.cf"
+  # end
+  #
+  # You can also configure and bootstrap a client to an existing
+  # policy server:
+  #
+  # config.vm.provision "cfengine" do |cf|
+  #   cf.policy_server_address = "10.0.2.15"
+  # end
+
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file default.pp in the manifests_path directory.
+  #
+  # config.vm.provision "puppet" do |puppet|
+  #   puppet.manifests_path = "manifests"
+  #   puppet.manifest_file  = "default.pp"
+  # end
+
+  # Enable provisioning with Chef Solo, specifying a cookbooks path, roles
+  # path, and data_bags path (all relative to this Vagrantfile), and adding
+  # some recipes and/or roles.
+  #
+  # config.vm.provision "chef_solo" do |chef|
+  #   chef.cookbooks_path = "~/chef/cookbooks"
+  #   chef.roles_path     = "~/chef/roles"
+  #   chef.data_bags_path = "~/chef/data_bags"
+  #
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   chef.json = { mysql_password: "foo" }
+  # end
+  #
+  # Chef Solo will automatically install the latest version of Chef for you.
+  # This can be configured in the provisioner block:
+  #
+  # config.vm.provision "chef_solo" do |chef|
+  #   chef.version = "11.16.4"
+  # end
+  #
+  # Alternative you can disable the installation of Chef entirely:
+  #
+  # config.vm.provision "chef_solo" do |chef|
+  #   chef.install = false
+  # end
+
+  # Enable provisioning with Chef Zero. The Chef Zero provisioner accepts the
+  # exact same parameter as the Chef Solo provisioner:
+  #
+  # config.vm.provision "chef_zero" do |chef|
+  #   chef.cookbooks_path = "~/chef/cookbooks"
+  #   chef.roles_path     = "~/chef/roles"
+  #   chef.data_bags_path = "~/chef/data_bags"
+  #
+  #   chef.add_recipe "mysql"
+  #   chef.add_role "web"
+  #
+  #   # You may also specify custom JSON attributes:
+  #   chef.json = { mysql_password: "foo" }
+  # end
+
+  # Enable provisioning with Chef Server, specifying the chef server URL,
+  # and the path to the validation key (relative to this Vagrantfile).
+  #
+  # The Hosted Chef platform uses HTTPS. Substitute your organization for
+  # ORGNAME in the URL and validation key.
+  #
+  # If you have your own Chef Server, use the appropriate URL, which may be
+  # HTTP instead of HTTPS depending on your configuration. Also change the
+  # validation key to validation.pem.
+  #
+  # config.vm.provision "chef_client" do |chef|
+  #   chef.chef_server_url     = "https://api.opscode.com/organizations/ORGNAME"
+  #   chef.validation_key_path = "ORGNAME-validator.pem"
+  # end
+  #
+  # If you're using the Hosted Chef platform, your validator client is
+  # ORGNAME-validator, replacing ORGNAME with your organization name.
+  #
+  # If you have your own Chef Server, the default validation client name is
+  # chef-validator, unless you changed the configuration.
+  #
+  #   chef.validation_client_name = "ORGNAME-validator"
+  #
+  # Chef Client will automatically install the latest version of Chef for you.
+  # This can be configured in the provisioner block:
+  #
+  # config.vm.provision "chef_client" do |chef|
+  #   chef.version = "11.16.4"
+  # end
+  #
+  # Alternative you can disable the installation of Chef entirely:
+  #
+  # config.vm.provision "chef_client" do |chef|
+  #   chef.install = false
+  # end
+
+  # Enable provisioning with Chef Apply, specifying an inline recipe to execute
+  # on the target system.
+  #
+  # config.vm.provision "chef_apply" do |chef|
+  #   chef.recipe = <<-RECIPE
+  #     package "curl"
+  #   RECIPE
+  # end
+  #
+  # Chef Apply will automatically install the latest version of Chef for you.
+  # This can be configured in the provisioner block:
+  #
+  # config.vm.provision "chef_apply" do |chef|
+  #   chef.version = "11.16.4"
+  # end
+end

--- a/template/bin/hubot
+++ b/template/bin/hubot
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -eu
+
+if [ -z "${DISABLE_NPM_INSTALL-}" ]; then
+  npm install
+fi
+export PATH="node_modules/.bin:node_modules/lisb-hubot/node_modules/.bin:$PATH"
+
+if [ -f .env ]; then
+  `grep '^[^# ]*=' .env | sed 's/^/export /'`
+fi
+
+FID=${PWD##*/}
+FID=${FID// /_}
+FOPT="\
+    --uid $FID \
+    --minUptime 10000 --spinSleepTime 600000 \
+    -o hubot.log -e hubot-err.log -a \
+    -w --watchDirectory scripts/ \
+    -c coffee node_modules/.bin/hubot -a direct ${@:2:$#} \
+"
+
+if [ -z "${REDIS_URL-}" ]; then
+  export REDIS_URL=redis://localhost:6379/$FID
+fi
+
+case ${1-} in
+run)
+  forever $FOPT
+  ;;
+start)
+  if pgrep -fo $PWD/node_modules/.bin/hubot > /dev/null ; then
+    echo "${FID} already Started: "
+    exit 1
+  fi
+  forever start $FOPT
+  ;;
+stop|restart)
+  forever $1 $FID
+  ;;
+status)
+  forever list | grep "] $FID "
+  ;;
+logs)
+  tail -f hubot.log
+  ;;
+*)
+  exec node_modules/.bin/hubot -a direct "$@"
+  ;;
+esac

--- a/template/bin/hubot.cmd
+++ b/template/bin/hubot.cmd
@@ -1,0 +1,35 @@
+@echo off
+
+rem installer bug. http://stackoverflow.com/a/25095327
+mkdir "%APPDATA%\npm" > NUL 2>&1
+
+set PATH=node_modules\.bin;node_modules\lisb-hubot\node_modules\.bin;%PATH%
+call npm install
+
+for /f "delims=\" %%i in ("%CD%") do set UID=%%i
+
+for /f "tokens=1,2 delims==" %%i in (.env) do set %%i=%%j
+
+if "%REDIS_URL%" == "" (
+  set REDIS_URL=redis://localhost:6379/%UID%
+)
+
+if "%1" == "start" (
+  forever start ^
+    --uid "%UID%" ^
+    --minUptime 10000 --spinSleepTime 600000 ^
+    -o hubot.log -a ^
+    -w --watchDirectory scripts ^
+    -c coffee node_modules\.bin\hubot.cmd -a direct %*
+) else if "%1" == "stop" (
+  forever stop "%UID%"
+) else if "%1" == "restart" (
+  forever restart "%UID%"
+) else if "%1" == "status" (
+  forever list | find "] %UID% "
+) else if "%1" == "logs" (
+  cat hubot.log | more
+) else (
+  node_modules\.bin\hubot.cmd -a direct %*
+)
+

--- a/template/external-scripts.json
+++ b/template/external-scripts.json
@@ -1,0 +1,1 @@
+["lisb-hubot-redis-brain"]

--- a/template/package.json
+++ b/template/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "starter",
-  "version": "0.3.9",
+  "name": "<%= packageName %>",
+  "version": "<%= version %>",
   "private": true,
 
   "scripts": {
     "start": "bin/hubot run"
   },
-  
-  "author": "L is B corp.",
+
+  "author": "<%= author %>",
 
   "keywords": [
     "hubot",
@@ -16,7 +16,7 @@
     "daab"
   ],
 
-  "description": "A simple helpful robot for your Company",
+  "description": "<%= description %>",
 
   "dependencies": {
     "lisb-hubot":    "^3.3.2",

--- a/template/package.json
+++ b/template/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "starter",
+  "version": "0.3.9",
+  "private": true,
+
+  "scripts": {
+    "start": "bin/hubot run"
+  },
+  
+  "author": "L is B corp.",
+
+  "keywords": [
+    "hubot",
+    "direct",
+    "bot",
+    "daab"
+  ],
+
+  "description": "A simple helpful robot for your Company",
+
+  "dependencies": {
+    "lisb-hubot":    "^3.3.2",
+    "lisb-hubot-redis-brain": "^1.0.0",
+    "lisb-forever": "^1.0.0"
+  }
+}

--- a/template/scripts/ping.js
+++ b/template/scripts/ping.js
@@ -1,0 +1,26 @@
+// Description:
+//   Utility commands surrounding Hubot uptime.
+//
+// Commands:
+//   ping - Reply with pong
+//   echo <text> - Reply back with <text>
+//   time - Reply with current time
+'use strict';
+
+module.exports = (robot) => {
+  robot.respond(/PING$/i, (res) => {
+    res.send('PONG');
+  });
+
+  robot.respond(/ADAPTER$/i, (res) => {
+    res.send(robot.adapterName);
+  });
+
+  robot.respond(/ECHO (.*)$/i, (res) => {
+    res.send(res.match[1]);
+  });
+
+  robot.respond(/TIME$/i, (res) => {
+    res.send(`Server time is: ${new Date()}`);
+  });
+};


### PR DESCRIPTION
`daab init` を `daab-starter` の `git clone` ではなく，`template/` からコピーする形式に変更します．このとき，`npm init` のようにユーザー入力も反映します．

既存の daab プロジェクトには (init のみなので) 影響しないはず．

`daab-starter` リポジトリは read only にしておけば良いかなと思います．

----
スクリーンショット (実行途中)
<img width="341" alt="daab-init-1" src="https://user-images.githubusercontent.com/567050/75401857-bc4d8080-5946-11ea-8f58-85604575fcd9.png">

スクリーンショット (実行完了)
<img width="398" alt="daab-init-2" src="https://user-images.githubusercontent.com/567050/75401882-c96a6f80-5946-11ea-87a2-44a6bfe5ca79.png">
