### PR TITLE
chore: `template/` 以下のファイルは無視しない

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
   "bin": {
     "daab": "lib/daab.js"
   },
+  "files": [
+    "lib",
+    "template"
+  ],
   "dependencies": {
     "commander": "^2.8.1",
     "direct-js": "^0.1.33",


### PR DESCRIPTION
`template/.gitignore` が pack 時に無視されてしまうので，これを防ぐための対応です．

daab@0.1.9 の npm pack --dry-run で include されるファイル一覧
```
LICENSE
README.md
lib/auth.js
lib/daab-deploy.js
lib/daab-init.js
lib/daab-invites.js
lib/daab-login.js
lib/daab-logout.js
lib/daab-run.js
lib/daab-start.js
lib/daab-stop.js
lib/daab.js
lib/git.js
package.json
```

今回の対応で include されるファイル一覧
```
LICENSE
README.md
lib/auth.js
lib/daab-deploy.js
lib/daab-init.js
lib/daab-invites.js
lib/daab-login.js
lib/daab-logout.js
lib/daab-run.js
lib/daab-start.js
lib/daab-stop.js
lib/daab.js
lib/git.js
lib/template.js
package.json
template/.cfignore
template/.dockerignore
template/.gitignore
template/Berksfile
template/Dockerfile
template/Procfile
template/Vagrantfile
template/bin/hubot
template/bin/hubot.cmd
template/external-scripts.json
template/package.json
template/scripts/.foreverignore
template/scripts/ping.js
```

上記の差分
```diff
$ diff 0.1.9.list hotfix.list
13a14
> lib/template.js
14a16,28
> template/.cfignore
> template/.dockerignore
> template/.gitignore
> template/Berksfile
> template/Dockerfile
> template/Procfile
> template/Vagrantfile
> template/bin/hubot
> template/bin/hubot.cmd
> template/external-scripts.json
> template/package.json
> template/scripts/.foreverignore
> template/scripts/ping.js
```

参考:
<https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package>