### PR TITLE
Feature/update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
   "dependencies": {
     "@npmcli/arborist": "^4.0.4",
     "commander": "^2.8.1",
-    "direct-js": "^0.1.33",
+    "direct-js": "^1.111.6",
     "dotenv": "^4.0.0",
     "inquirer": "^7.0.4",
-    "mem-fs-editor": "^6.0.0",
+    "mem-fs-editor": "^9.3.0",
     "read": "^1.0.7",
     "rimraf": "^2.6.2",
-    "yeoman-environment": "^2.8.0"
+    "yeoman-environment": "^3.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
   "bin": {
     "daab": "lib/daab.js"
   },
+  "engines": {
+    "node": ">=12"
+  },
   "files": [
     "lib",
     "template"


### PR DESCRIPTION
```sh
$ npm install                             
npm WARN deprecated har-validator@5.1.5: this library is no longer supported      
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.
  See https://v8.dev/blog/math-random for details.                                
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
                                          
added 386 packages, and audited 387 packages in 29s
                                                                                    
40 packages are looking for funding                                                 
  run `npm fund` for details                                                        
                                                                                    
found 0 vulnerabilities
```