### PR TITLE
Revert "chore(template): hubot-redis-brain を利用する"

### DIFF
--- a/template/external-scripts.json
+++ b/template/external-scripts.json
@@ -1,1 +1,1 @@
-["hubot-redis-brain"]
+["lisb-hubot-redis-brain"]

--- a/template/package.json
+++ b/template/package.json
@@ -21,7 +21,7 @@
     "forever": "^4.0.0",
     "hubot-direct": ">=3 <4",
     "lisb-hubot": ">=5 <6",
-    "hubot-redis-brain": ">=1.1.0 <2"
+    "lisb-hubot-redis-brain": "^1.0.0"
   },
   "overrides": {
     "chokidar": {


### PR DESCRIPTION
最新版の `hubot-redis-brain` はまだ正常に動作しないため，一旦元に戻します．